### PR TITLE
refactor(EditCard) : mbti 버튼 수정 및 디자인 적용

### DIFF
--- a/src/components/RadioSelector.jsx
+++ b/src/components/RadioSelector.jsx
@@ -13,28 +13,30 @@ const RadioSelector = forwardRef((props, ref) => {
       <Container>
         {`${guideText[0]}형? vs ${guideText[1]}형?`}
         <div style={{ display: 'flex' }}>
-          <RadioInputBox direction="L">
-            <input
-              type="radio"
-              ref={ref}
-              id={optionA}
-              name={optionA + optionB}
-              value={optionA}
-              onChange={handleInputChange}
-              defaultChecked
-            />
-            <label htmlFor={optionA}>{optionA}</label>
-          </RadioInputBox>
-          <RadioInputBox direction="R">
-            <input
-              type="radio"
-              id={optionB}
-              name={optionA + optionB}
-              value={optionB}
-              onChange={handleInputChange}
-            />
-            <label htmlFor={optionB}>{optionB} </label>
-          </RadioInputBox>
+          <RadioInput
+            type="radio"
+            ref={ref}
+            id={optionA}
+            name={optionA + optionB}
+            value={optionA}
+            direction="L"
+            onChange={handleInputChange}
+            defaultChecked
+          />
+          <RadioInputLabel direction="L" htmlFor={optionA}>
+            {optionA}
+          </RadioInputLabel>
+          <RadioInput
+            type="radio"
+            id={optionB}
+            name={optionA + optionB}
+            value={optionB}
+            direction="R"
+            onChange={handleInputChange}
+          />
+          <RadioInputLabel direction="R" htmlFor={optionB}>
+            {optionB}
+          </RadioInputLabel>
         </div>
       </Container>
     </>
@@ -48,7 +50,7 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const RadioInputBox = styled.div`
+const RadioInputLabel = styled.label`
   border: 1px solid #a3a3a3;
   border-right: ${(props) => props.direction === 'L' && 'none'};
   border-radius: ${(props) => (props.direction === 'L' ? '8px 0px 0px 8px' : '0px 8px 8px 0px')};
@@ -56,6 +58,19 @@ const RadioInputBox = styled.div`
   height: 24px;
   display: flex;
   justify-content: center;
+  cursor: pointer;
+`;
+
+const RadioInput = styled.input.attrs({ type: 'radio' })`
+  &:checked + ${RadioInputLabel} {
+    background-color: ${(props) => (props.direction === 'L' ? '#AB9FED' : '#FE94C1')};
+    color: white;
+  }
+  display: block;
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  z-index: -1;
 `;
 
 export default RadioSelector;


### PR DESCRIPTION
### 작업 사항

- RadioInputBox 삭제

  - 아예 label (RadioInputLabel) 을 RadioInputBox 모양으로 바꿔버려서 필요 없어짐

- RadioInputLabel 컴포넌트 생성 (RadioInput에 붙는 label 태그)

- RadioInput 컴포넌트 생성

### 실행 화면

![test](https://github.com/rookieton-fox/rookieton-card-FE/assets/87255462/eb3fe89e-f95b-4be4-8622-657c8c89c84b)
