### PR TITLE
design(MenuModal): 모달 높이 조절

### DIFF
--- a/src/components/MenuModal.jsx
+++ b/src/components/MenuModal.jsx
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 import close_button from '../assets/close_button.svg';
 import logo from '../assets/logo.svg';
 import { serviceIntro, serviceCreator, servicePolicy, serviceCaution } from '../assets/MenuText';
+import { useEffect } from 'react';
 
 const MenuModal = (props) => {
   const { title, onClickClose } = props;
@@ -14,6 +15,11 @@ const MenuModal = (props) => {
   };
 
   const text = setText();
+
+  useEffect(() => {
+    document.body.style = `overflow: hidden`;
+    return () => (document.body.style = `overflow: auto`);
+  }, []);
 
   return (
     <Container onClick={onClickClose}>
@@ -51,6 +57,7 @@ const Container = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
   position: fixed;
   top: 0;
+  left: 0;
   width: 100vw;
   height: 100vh;
   display: flex;


### PR DESCRIPTION
### 작업 사항

- MenuModal 높이를 40px 줄였습니다.

- MenuModal이 열린 상태에서 외부 영역이 스크롤 되지 않게 막았습니다.

### 실행 화면
![test](https://github.com/rookieton-fox/rookieton-card-FE/assets/87255462/43984b90-f71b-4cd8-bcb6-cdbd32be3a7d)
